### PR TITLE
feat: certify the builds

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   binary:
     name: Create
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -23,23 +27,46 @@ jobs:
             installable: .#dune-static
 
     runs-on: ${{ matrix.os }}
+    outputs:
+      git-commit: ${{ steps.git-commit.outputs.hash }}
     steps:
+
       - uses: actions/checkout@v4
         with:
           repository: ocaml/dune
           ref: main # At some point we might need to change it to point to a developer preview branch
           fetch-depth: 0 # for git describe
+
       - uses: cachix/install-nix-action@v22
       - run: echo "(version $(git describe --always --dirty --abbrev=7))" >> dune-project
       - run: nix build ${{ matrix.installable }}
+
+      - name: Extract commit
+        id: git-commit
+        run: echo "hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        id: certificate
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "result/bin/dune"
+          show-summary: false
+
+      - name: Extract artifact and attestation
+        run: |
+          mkdir -p ~/build/
+          cp ${{ steps.certificate.outputs.bundle-path }} result/bin/dune ~/build/
+
       - uses: actions/upload-artifact@v4
         with:
-          path: result/bin/dune
+          path: ~/build/*
           name: ${{ matrix.name }}
 
   deploy-s3:
     runs-on: ubuntu-latest
     needs: binary
+    permissions:
+      contents: write
     steps:
 
       - name: Install rclone
@@ -60,7 +87,6 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
 
-
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -75,7 +101,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          path: ~/artifacts
+          path: /home/runner/artifacts
 
       - name: Move artifacts to scope
         run: mv "/home/runner/artifacts" "."
@@ -85,7 +111,8 @@ jobs:
 
       - name: Export executables and generate html
         shell: bash
-        run: ./sandworm/_build/install/default/bin/sandworm
+        run: ./sandworm/_build/install/default/bin/sandworm --with-certificate --commit "${{ needs.binary.outputs.git-commit }}"
+
 
       - name: Commit changes to branch
         run: |

--- a/main.css
+++ b/main.css
@@ -74,14 +74,14 @@ ol {
     padding-left: 2rem;
 }
 
-li.task-list-item{
+li.task-list-item {
     list-style-type: none;
 }
 
-input.task-list-item-checkbox{
+input.task-list-item-checkbox {
     float: left;
     margin: .31em 0 .2em -1.3em !important;
-    vertical-align: middle;   
+    vertical-align: middle;
 }
 
 main {
@@ -103,6 +103,10 @@ a:focus,
 a:hover {
     color: #23527c;
     text-decoration: underline;
+}
+
+.certificate {
+    color: grey;
 }
 
 a:focus {
@@ -144,7 +148,7 @@ a:focus {
     padding: 15px;
 }
 
-hr{
+hr {
     margin: 24px 0px;
     height: .25rem;
     background-color: var(--hr-color);
@@ -163,32 +167,32 @@ blockquote {
     padding: 0 1rem;
 }
 
-span.blockquoteX{
+span.blockquoteX {
     display: block;
     font-size: 80%;
 }
 
-span.blockquoteX::before{
+span.blockquoteX::before {
     content: '\2014 \00A0';
 }
 
 span.material-symbols-outlined {
     font-variation-settings:
-    'FILL' 0,
-    'wght' 400,
-    'GRAD' 0,
-    'opsz' 48;
+        'FILL' 0,
+        'wght' 400,
+        'GRAD' 0,
+        'opsz' 48;
     font-size: 1rem;
     margin: 3px 5px;
     vertical-align: bottom;
 }
 
-span.material-symbols-outlined-fill{
+span.material-symbols-outlined-fill {
     font-variation-settings:
-    'FILL' 1,
-    'wght' 400,
-    'GRAD' 0,
-    'opsz' 48;
+        'FILL' 1,
+        'wght' 400,
+        'GRAD' 0,
+        'opsz' 48;
 }
 
 table {
@@ -227,16 +231,16 @@ pre {
     line-height: 1.45;
 }
 
-code{
+code {
     padding: .2em;
     margin: 0;
     font-size: 85%;
     border-radius: 3px;
     background-color: var(--body-background);
-    font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
-dl dt{
+dl dt {
     padding: 0;
     margin-top: 16px;
     font-style: italic;
@@ -275,23 +279,23 @@ mark {
 }
 
 /*---embed---*/
-embed{
-    overflow: auto; 
-    width: 100%; 
+embed {
+    overflow: auto;
+    width: 100%;
     height: 400px;
 }
 
-iframe{
+iframe {
     margin: 10px auto;
-    width: 100%; 
+    width: 100%;
     height: 480px;
 }
 
-.gist table tr{
+.gist table tr {
     border: 0px;
 }
 
-.gist table td{
+.gist table td {
     border: 0px;
 }
 

--- a/sandworm/bin/dune
+++ b/sandworm/bin/dune
@@ -1,4 +1,4 @@
 (executable
  (public_name sandworm)
  (name main)
- (libraries sandworm))
+ (libraries sandworm cmdliner))

--- a/sandworm/bin/main.ml
+++ b/sandworm/bin/main.ml
@@ -1,9 +1,11 @@
 open Sandworm
 
-let () =
+let main commit has_certificate =
   let () = Format.printf "--> Start to build website\n" in
   let bundle = Metadata.import_from_json Config.metadata_file in
-  let daily_bundle = Metadata.(Bundle.create_daily Target.defaults) in
+  let daily_bundle =
+    Metadata.(Bundle.create_daily ~commit ~has_certificate Target.defaults)
+  in
   let daily_bundle_date = Metadata.Bundle.get_data_string_from daily_bundle in
   let s3_daily_bundle = Filename.concat Config.s3_bucket_ref daily_bundle_date in
   let () =
@@ -15,4 +17,25 @@ let () =
     Web.export_bundle_to_file ~url:Config.s3_public_url ~file:Config.html_path bundles
   in
   Format.printf "--> Export completed ✓\n"
+;;
+
+open Cmdliner
+
+let info = Cmd.info "sandworm"
+
+let term =
+  let open Term.Syntax in
+  let+ commit =
+    let doc = "The build commit hash." in
+    Arg.(value & opt (some string) None & info ~doc [ "c"; "commit" ])
+  and+ has_certificate =
+    let doc = "Indicate that the build produced a certificate." in
+    Arg.(value & flag & info ~doc [ "with-certificate" ])
+  in
+  main commit has_certificate
+;;
+
+let () =
+  let cmd = Cmd.v info term in
+  Cmd.eval cmd |> exit
 ;;

--- a/sandworm/dune-project
+++ b/sandworm/dune-project
@@ -23,6 +23,7 @@
           tyxml
           ptime
           fpath
+          cmdliner
           (ocaml-lsp-server :with-dev-setup)
           (ocamlformat :with-dev-setup)))
 

--- a/sandworm/lib/metadata.ml
+++ b/sandworm/lib/metadata.ml
@@ -30,10 +30,14 @@ module Bundle = struct
   type t =
     { date : pdate
     ; targets : Target.t list
+    ; has_certificate : (bool[@default false])
+    ; commit : (string option[@default None])
     }
   [@@deriving yojson]
 
-  let create ~date targets = { date; targets }
+  let create ~date ~commit ~has_certificate targets =
+    { date; targets; commit; has_certificate }
+  ;;
 
   let create_daily targets =
     let date = Unix.time () |> Ptime.of_float_s |> Option.get |> Ptime.to_date in

--- a/sandworm/sandworm.opam
+++ b/sandworm/sandworm.opam
@@ -15,6 +15,7 @@ depends: [
   "tyxml"
   "ptime"
   "fpath"
+  "cmdliner"
   "ocaml-lsp-server" {with-dev-setup}
   "ocamlformat" {with-dev-setup}
   "odoc" {with-doc}


### PR DESCRIPTION
## Summary :notebook: 

I was finally able to complete this PR after some deployment issues. The goal of this PR is to ensure we are more transparent in the way we build our binaries. To achieve this goal, we are now doing two things:
1. We use artifact certificates for each build thanks to GitHub Actions ([documentation here](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)) :lock: The certificates are uploaded to the server and can be verified using `gh` from GitHub. I didn't add the `SHA256` as the certificate mechanism is stronger than the `SHA256`. Don't hesitate to tell me if you think it is a must to have!
2. It displays the commit when we build `dune`. It is easier for the user to check in the `dune` repository with the commit than with the `git-describe` version. 

To simplify the usability, I have introduced a command line interface (simple one):
- `--with-certificates` add a link with the certificates in the `index.html` file and an entry in the `metada.json` file.
- `-c | --commit <hash>` allows us to specify a commit when the build was made. It also adds an entry in the `metadata.json` file.

## Preview :paintbrush: 

I have changed a bit of the CSS, but most of the diff comes from a preinstallation prettier.

![preview image](https://github.com/user-attachments/assets/6e66c2ae-4550-406b-8b76-b2aab3ee7313)

The visual changes are:
- a `Verify` paragraph with an explanation on how to verify the binary
- a `certificate | no certificate` link next to each 
- a `(commit: <hash>)` mention next to every build date

## Tracking

Apart from the compile time configuration to activate the feature from the developer preview by default, this is the last step before adding the banner to `ocaml.org` for the _distribution preview website_.

Closes tarides/team-build-system#38
