### PR TITLE
feat: support latest binary downloading

### DIFF
--- a/sandworm/bin/main.ml
+++ b/sandworm/bin/main.ml
@@ -11,10 +11,6 @@ let main commit has_certificate =
   let () =
     Rclone.copy ~config_path:Config.rclone_path Config.artifacts_path s3_daily_bundle
   in
-  let latest_bundle = Filename.concat Config.s3_bucket_ref "latest" in
-  let () =
-    Rclone.copy ~config_path:Config.rclone_path Config.artifacts_path latest_bundle
-  in
   let bundles = Metadata.insert_unique daily_bundle bundle in
   let () = Metadata.export_to_json Config.metadata_file bundles in
   let () =

--- a/sandworm/bin/main.ml
+++ b/sandworm/bin/main.ml
@@ -6,10 +6,14 @@ let main commit has_certificate =
   let daily_bundle =
     Metadata.(Bundle.create_daily ~commit ~has_certificate Target.defaults)
   in
-  let daily_bundle_date = Metadata.Bundle.get_data_string_from daily_bundle in
+  let daily_bundle_date = Metadata.Bundle.get_date_string_from daily_bundle in
   let s3_daily_bundle = Filename.concat Config.s3_bucket_ref daily_bundle_date in
   let () =
     Rclone.copy ~config_path:Config.rclone_path Config.artifacts_path s3_daily_bundle
+  in
+  let latest_bundle = Filename.concat Config.s3_bucket_ref "latest" in
+  let () =
+    Rclone.copy ~config_path:Config.rclone_path Config.artifacts_path latest_bundle
   in
   let bundles = Metadata.insert_unique daily_bundle bundle in
   let () = Metadata.export_to_json Config.metadata_file bundles in

--- a/sandworm/lib/metadata.ml
+++ b/sandworm/lib/metadata.ml
@@ -44,7 +44,7 @@ module Bundle = struct
     create ~date targets
   ;;
 
-  let get_data_string_from t =
+  let get_date_string_from t =
     let y, m, d = t.date in
     Format.sprintf "%d-%02d-%02d" y m d
   ;;


### PR DESCRIPTION
This PR adds a `/latest/<arch>` URL to the Dune Binary Distribution system. Also, it provides a mechanism to update the binaries every time it is build with the latest version. It makes it easier for users to grab the dune version. 

The website displays a `Latest` section at the top, which are just pointers to the latest built binaries.

This PR must be merged after #4 to make sure we have certificates available for the latest build.