### PR TITLE
feat: ensure unicity of each bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The web page is deployed on [dune.ci.dev](https://dune.ci.dev).
 
 > :hourglass: The pipeline is triggered every day at _01:00 UTC_.
 
+> [!CAUTION]
+> The _metadata.json_ file must not be modified manually. If you do so, expect some unexpected behaviours.
+
 
 ## Installation & configuration
 

--- a/sandworm/bin/main.ml
+++ b/sandworm/bin/main.ml
@@ -11,7 +11,7 @@ let main commit has_certificate =
   let () =
     Rclone.copy ~config_path:Config.rclone_path Config.artifacts_path s3_daily_bundle
   in
-  let bundles = daily_bundle :: bundle in
+  let bundles = Metadata.insert_unique daily_bundle bundle in
   let () = Metadata.export_to_json Config.metadata_file bundles in
   let () =
     Web.export_bundle_to_file ~url:Config.s3_public_url ~file:Config.html_path bundles

--- a/sandworm/lib/metadata.ml
+++ b/sandworm/lib/metadata.ml
@@ -48,9 +48,21 @@ module Bundle = struct
     let y, m, d = t.date in
     Format.sprintf "%d-%02d-%02d" y m d
   ;;
+
+  let compare b1 b2 =
+    let p1 = Ptime.of_date b1.date |> Option.get in
+    let p2 = Ptime.of_date b2.date |> Option.get in
+    Ptime.compare p1 p2
+  ;;
 end
 
 type t = Bundle.t list [@@deriving yojson]
+
+let insert_unique bundle = function
+  | [] -> [ bundle ]
+  | bundle_cheked :: bs as bundles ->
+    if Bundle.compare bundle bundle_cheked = 0 then bundle :: bs else bundle :: bundles
+;;
 
 let import_from_json file : t = Yojson.Safe.from_file file |> of_yojson |> Result.get_ok
 let export_to_json file t = to_yojson t |> Yojson.Safe.to_file file

--- a/sandworm/lib/metadata.ml
+++ b/sandworm/lib/metadata.ml
@@ -49,10 +49,10 @@ module Bundle = struct
     Format.sprintf "%d-%02d-%02d" y m d
   ;;
 
-  let compare b1 b2 =
+  let equal b1 b2 =
     let p1 = Ptime.of_date b1.date |> Option.get in
     let p2 = Ptime.of_date b2.date |> Option.get in
-    Ptime.compare p1 p2
+    Ptime.equal p1 p2
   ;;
 end
 
@@ -61,7 +61,7 @@ type t = Bundle.t list [@@deriving yojson]
 let insert_unique bundle = function
   | [] -> [ bundle ]
   | bundle_cheked :: bs as bundles ->
-    if Bundle.compare bundle bundle_cheked = 0 then bundle :: bs else bundle :: bundles
+    if Bundle.equal bundle bundle_cheked then bundle :: bs else bundle :: bundles
 ;;
 
 let import_from_json file : t = Yojson.Safe.from_file file |> of_yojson |> Result.get_ok


### PR DESCRIPTION
This PR ensures that the _metadata.json_ file is the reflection of the situation on the S3 bucket. It makes sure that every date is related to the last binary information.

 Indeed, every time we trigger the build the same day, it would add a new section with the new information and override the binary in the S3 bucket. However, it would add a new section in _index.html_, instead of updating it.  This is __not__ the behavior we want. 

_metadata.json_ must respect the uniqueness invariant: we have only __one__ build for each day, corresponding to the last build we made.