### PR TITLE
feat: reduce binary size with strip

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -45,6 +45,9 @@ jobs:
         id: git-commit
         run: echo "hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Remove unused symbols
+        run: strip -s result/bin/dune
+
       - name: Generate artifact attestation
         id: certificate
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
By using `strip` we could reduce the size of our binaries, thanks to @gridbugs suggestion :+1: 
The flag is for removing all symbols and relocation information:
>  -s --strip-all   Remove all symbol and relocation information