### PR TITLE
fix: temporary add a patch on dune for building the correct targets

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -18,18 +18,24 @@ jobs:
         include:
           - os: macos-13
             name: x86_64-apple-darwin
-            installable: .#
+            installable: .#dune-experimental
           - os: macos-14
             name: aarch64-apple-darwin
-            installable: .#
+            installable: .#dune-experimental
           - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
-            installable: .#dune-static
+            installable: .#dune-static-experimental
 
     runs-on: ${{ matrix.os }}
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}
     steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "WARNING: Store patch in tmp"
+        run: mv ./dune-nix.patch /tmp
 
       - uses: actions/checkout@v4
         with:
@@ -39,6 +45,14 @@ jobs:
 
       - uses: cachix/install-nix-action@v22
       - run: echo "(version $(git describe --always --dirty --abbrev=7))" >> dune-project
+
+      - name: "WARNING: import and apply dune nix patch"
+        run: |
+          git config --global user.email "temporary@tarides.com"
+          git config --global user.name "Temporary patch"
+          mv /tmp/dune-nix.patch .
+          git am dune-nix.patch
+
       - run: nix build ${{ matrix.installable }}
 
       - name: Extract commit

--- a/dune-nix.patch
+++ b/dune-nix.patch
@@ -1,0 +1,65 @@
+From 1412a86e24c7fc2590694b02e63417805e9ed371 Mon Sep 17 00:00:00 2001
+From: Etienne Marais <dev@maiste.fr>
+Date: Fri, 23 Aug 2024 16:59:35 +0200
+Subject: [PATCH] chore(nix): support build for experimental feature
+
+Signed-off-by: Etienne Marais <dev@maiste.fr>
+---
+ flake.nix | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/flake.nix b/flake.nix
+index ffa31ef92..2bb4219f2 100644
+--- a/flake.nix
++++ b/flake.nix
+@@ -55,10 +55,38 @@
+           });
+         });
+       };
++      dune-experimental-overlay = self: super: {
++        ocamlPackages = super.ocaml-ng.ocamlPackages_4_14.overrideScope
++          (oself: osuper: {
++            dune_3 = osuper.dune_3.overrideAttrs (a: {
++              src = ./.;
++              preBuild = "./configure --enable-toolchains --enable-pkg-build-progress";
++            });
++          });
++      };
++      dune-static-experimental-overlay = self: super: {
++        ocamlPackages = super.ocaml-ng.ocamlPackages_4_14.overrideScope (oself: osuper: {
++          dune_3 = osuper.dune_3.overrideAttrs (a: {
++            src = ./.;
++            preBuild = ''
++              ./configure --enable-toolchains --enable-pkg-build-progress
++              ocaml boot/bootstrap.ml --static'';
++          });
++        });
++      };
++
+       pkgs-static = nixpkgs.legacyPackages.${system}.appendOverlays [
+         ocaml-overlays.overlays.default
+         dune-static-overlay
+       ];
++      pkgs-experimental = nixpkgs.legacyPackages.${system}.appendOverlays [
++        ocaml-overlays.overlays.default
++        dune-experimental-overlay
++      ];
++      pkgs-static-experimental = nixpkgs.legacyPackages.${system}.appendOverlays [
++        ocaml-overlays.overlays.default
++        dune-static-experimental-overlay
++      ];
+ 
+       ocamlformat =
+         let
+@@ -102,6 +130,8 @@
+         };
+         dune = self.packages.${system}.default;
+         dune-static = pkgs-static.pkgsCross.musl64.ocamlPackages.dune;
++        dune-experimental = pkgs-experimental.dune_3;
++        dune-static-experimental = pkgs-static-experimental.pkgsCross.musl64.ocamlPackages.dune;
+       };
+ 
+       devShells =
+-- 
+2.46.0
+


### PR DESCRIPTION
This is a workaround until the patch is merged in `ocaml/dune`. It applies the Nix configuration to unlock the dune-experimental and
dune-static-experimental targets. The patch is extracted from https://github.com/ocaml/dune/pull/10845/files.