### PR TITLE
test: check binaries are correct before pushing

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -88,9 +88,46 @@ jobs:
           path: ~/build/*
           name: ${{ matrix.name }}
 
+
+
+  check-artifacts:
+    strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - os: macos-13
+              name: x86_64-apple-darwin
+            - os: macos-14
+              name: aarch64-apple-darwin
+            - os: ubuntu-22.04
+              name: x86_64-unknown-linux-musl
+
+    runs-on: ${{ matrix.os }}
+    needs: binary
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+
+      - name: Get dune accessible
+        run: |
+          mv ./${{ matrix.name }}/dune ./dune
+          chmod u+x ./dune
+
+      - name: Check dune is working
+        run: |
+            export PATH="$PWD:$PATH"
+            cd test
+            dune pkg lock
+            dune build
+
+
+
   deploy-s3:
     runs-on: ubuntu-latest
-    needs: binary
+    needs: check-artifacts
     permissions:
       contents: write
     steps:

--- a/test/dune-project
+++ b/test/dune-project
@@ -1,0 +1,12 @@
+(lang dune 3.16)
+(name dune_test)
+(generate_opam_files true)
+
+(authors "The build system team")
+(maintainers "The build system team")
+(license ISC)
+
+(package
+ (name dune_test)
+ (allow_empty)
+ (depends ocaml dune sqlite3))


### PR DESCRIPTION
Following a discussion with @gridbugs, I propose a simple test to check that the binary are set with the correct flags. It simply tries to lock a package with one dependency (sqlite3 because it's a package with few deps) and run dune build. This is another step to try and verify that our binaries are correct before pushing them.

_N.B_: reopening of #21 