### PR TITLE
fix: use the correct GH path for commits

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: "WARNING: Store patches in tmp"
+      - name: "WARNING: Store patch(es) in tmp"
         run: |
           mv ./dune-locking.patch /tmp
 
@@ -48,12 +48,13 @@ jobs:
 
       - name: Extract build informations
         id: git-commit
-        run: |
-          GIT_REVISION=$(git rev-parse HEAD)
-          echo "hash=$GIT_REVISION" >> "$GITHUB_OUTPUT"
-          echo "(version \"Dune Developer Preview: build $(date --iso-8601=seconds), git revision $GIT_REVISION\")" >> dune-project 
+        run: echo "hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: "WARNING: import and apply dune nix patch"
+      - name: Export version
+        run: |
+          echo "(version \"Dune Developer Preview: build $(date --iso-8601=seconds), git revision $(git rev-parse HEAD)\")" >> dune-project
+
+      - name: "WARNING: import and apply patch(es)"
         run: |
           git config --global user.email "temporary@tarides.com"
           git config --global user.name "Temporary patch"
@@ -165,7 +166,7 @@ jobs:
 
       - name: Export executables and generate html
         shell: bash
-        run: ./sandworm/_build/install/default/bin/sandworm sync --with-certificate --commit "${{ needs.binary.outputs.git-commit }}"
+        run: ./sandworm/_build/install/default/bin/sandworm sync --with-certificate --commit "${{ jobs.binary.outputs.git-commit }}"
 
 
       - name: Commit changes to branch


### PR DESCRIPTION
There was an issue with `needs` as `binary` was a transitive dep. The result was that it wasn't in the scope anymore. It makes the CI failed because no change (no new commit) was detected.